### PR TITLE
Show X error badge when no token is set

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -34,9 +34,11 @@
 			chrome.alarms.create({when: Date.now() + 2000 + (period * 60 * 1000)});
 
 			if (err) {
+				var symbol = '?';
 				switch (err.message) {
 					case 'missing token':
 						text = 'Missing access token, please create one and enter it in Options';
+						symbol = 'X';
 						break;
 					case 'server error':
 						text = 'You have to be connected to the internet';
@@ -50,7 +52,7 @@
 						break;
 				}
 
-				render('?', [166, 41, 41, 255], text);
+				render(symbol, [166, 41, 41, 255], text);
 				return;
 			}
 


### PR DESCRIPTION
This brings the change discussed in #22 

How do I test this? I tried loading the unpacked extension, but I never saw the error badge. Even after killing the network connection :disappointed: 