### PR TITLE
fix the "no participating notification leads to 404 bug" #48

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -87,10 +87,9 @@
 
 		if (window.GitHubNotify.settings.get('count') > 0) {
 			ghTab.url = `${url}notifications`;
-		}
-
-		if (window.GitHubNotify.settings.get('useParticipatingCount')) {
-			ghTab.url += '/participating';
+			if (window.GitHubNotify.settings.get('useParticipatingCount')) {
+				ghTab.url += '/participating';
+			}
 		}
 
 		if (typeof tab !== 'undefined' && (tab.url === '' || tab.url === 'chrome://newtab/' || tab.url === ghTab.url)) {


### PR DESCRIPTION
I fixed #48 issue.
I found #32 commit, so when notification count is <= 0, I change the code for not adding '/participating' to the url.